### PR TITLE
Added support for DelayedResponses

### DIFF
--- a/tomaat/extras/niftynet.py
+++ b/tomaat/extras/niftynet.py
@@ -4,9 +4,8 @@ import os
 import nibabel as nib
 import SimpleITK as sitk
 import numpy as np
-import time
 
-from tomaat.server import TomaatService
+from tomaat.server import TomaatServiceDelayedResponse
 
 
 # this extra works with model zoo from NiftyNet and in particular with highresnet3d_brain_parcellation model.
@@ -171,7 +170,7 @@ def start_service(config_file_path, ini_file_path):
 
     application = NiftyNetZooApp(ini_file_path)
 
-    service = TomaatService(
+    service = TomaatServiceDelayedResponse(
         config=config,
         app=application,
         input_interface=input_interface,

--- a/tomaat/server/service.py
+++ b/tomaat/server/service.py
@@ -341,7 +341,7 @@ class TomaatServiceDelayedResponse(TomaatService):
                 'content': 'The results of your earlier request {} have been received'.format(req_id),
                 'label': ''
             })
-            
+
             self.result_dict[req_id] = response
 
         delegated_process = Process(target=processing_thread, args=())

--- a/tomaat/server/service.py
+++ b/tomaat/server/service.py
@@ -336,6 +336,12 @@ class TomaatServiceDelayedResponse(TomaatService):
                 traceback.print_exc()
                 logger.error('Server-side ERROR during response message creation')
 
+            response.append({
+                'type': 'PlainText',
+                'content': 'The results of your earlier request {} have been received'.format(req_id),
+                'label': ''
+            })
+            
             self.result_dict[req_id] = response
 
         delegated_process = Process(target=processing_thread, args=())

--- a/tomaat/server/service.py
+++ b/tomaat/server/service.py
@@ -311,8 +311,6 @@ class TomaatService(object):
         
         return json.dumps(response)
 
-        return response
-
     def run(self):
         self.klein_app.run(port=self.config['port'], host='0.0.0.0')
         reactor.run()
@@ -331,6 +329,10 @@ class TomaatServiceDelayedResponse(TomaatService):
 
     def received_data_handler(self, request):
         req_id = str(uuid.uuid4()).replace('-', '')
+
+        savepath = os.path.join(tempfile.gettempdir(), req_id)
+
+        os.mkdir(savepath)
 
         def processing_thread():
             response = self.make_error_response('Server-side ERROR during processing')
@@ -367,6 +369,8 @@ class TomaatServiceDelayedResponse(TomaatService):
         self.reqest_list.append(req_id)
 
         response = [{'type': 'DelayedResponse', 'request_id': req_id}]
+
+        shutil.rmtree(savepath)
 
         return json.dumps(response)
 

--- a/tomaat/server/service.py
+++ b/tomaat/server/service.py
@@ -306,6 +306,10 @@ class TomaatService(object):
 
 
 class TomaatServiceDelayedResponse(TomaatService):
+    announcement_task = None
+
+    gpu_lock = DeferredLock()
+    
     multiprocess_manager = Manager()
     result_dict = multiprocess_manager.dict()
     reqest_list = multiprocess_manager.list()

--- a/tomaat/server/service.py
+++ b/tomaat/server/service.py
@@ -8,6 +8,7 @@ import base64
 import traceback
 import numpy as np
 
+from multiprocessing import Process, Manager
 from urllib2 import urlopen
 from klein import Klein
 from twisted.internet.defer import inlineCallbacks, returnValue, DeferredLock
@@ -157,8 +158,8 @@ class TomaatService(object):
         :type message: str error message to be returned to the client
         :return: response to be returned to client
         """
-        response = {'type': 'PlainText', 'content': message, 'label': 'Error!'}
-        return json.dumps(response)
+        response = [{'type': 'PlainText', 'content': message, 'label': 'Error!'}]
+        return response
 
     def parse_request(self, request):
         """
@@ -270,7 +271,7 @@ class TomaatService(object):
                 fiducial_str = ';'.join([','.join(map(str,fid_point)) for fid_point in fiducial_array])
                 message.append({'type': 'Fiducials', 'content': fiducial_str, 'label': ''})
 
-        return json.dumps(message)
+        return message
 
     def received_data_handler(self, request):
         try:
@@ -278,26 +279,118 @@ class TomaatService(object):
         except:
             traceback.print_exc()
             logger.error('Server-side ERROR during request parsing')
-            return self.make_error_response('Server-side ERROR during request parsing')
+            response = self.make_error_response('Server-side ERROR during request parsing')
+            return json.dumps(response)
 
         try:
             transformed_result = self.app(data, gpu_lock=self.gpu_lock)
         except:
             traceback.print_exc()
             logger.error('Server-side ERROR during processing')
-            return self.make_error_response('Server-side ERROR during processing')
+            response = self.make_error_response('Server-side ERROR during processing')
+            return json.dumps(response)
 
         try:
             response = self.make_response(transformed_result)
         except:
             traceback.print_exc()
             logger.error('Server-side ERROR during response message creation')
-            return self.make_error_response('Server-side ERROR during response message creation')
+            response = self.make_error_response('Server-side ERROR during response message creation')
+            return json.dumps(response)
 
-        return response
+        return json.dumps(response)
 
     def run(self):
         self.klein_app.run(port=self.config['port'], host='0.0.0.0')
         reactor.run()
 
 
+class TomaatServiceDelayedResponse(TomaatService):
+    multiprocess_manager = Manager()
+    result_dict = multiprocess_manager.dict()
+    reqest_list = multiprocess_manager.list()
+
+    klein_app = Klein()
+
+    def received_data_handler(self, request):
+        req_id = str(uuid.uuid4()).replace('-', '')
+
+        def processing_thread():
+            response = self.make_error_response('Server-side ERROR during processing')
+
+            try:
+                data = self.parse_request(request)
+            except:
+                traceback.print_exc()
+                logger.error('Server-side ERROR during request parsing')
+
+            try:
+                transformed_result = self.app(data, gpu_lock=self.gpu_lock)
+            except:
+                traceback.print_exc()
+                logger.error('Server-side ERROR during processing')
+
+            try:
+                response = self.make_response(transformed_result)
+            except:
+                traceback.print_exc()
+                logger.error('Server-side ERROR during response message creation')
+
+            self.result_dict[req_id] = response
+
+        delegated_process = Process(target=processing_thread, args=())
+        delegated_process.start()
+
+        self.reqest_list.append(req_id)
+
+        response = [{'type': 'DelayedResponse', 'request_id': req_id}]
+
+        return json.dumps(response)
+
+    @klein_app.route('/interface', methods=['GET'])
+    def interface(self, _):
+        return json.dumps(self.input_interface)
+
+    @klein_app.route('/predict', methods=['POST'])
+    @inlineCallbacks
+    def predict(self, request):
+        logger.info('predicting...')
+
+        result = yield threads.deferToThread(self.received_data_handler, request)
+
+        returnValue(result)
+
+    @klein_app.route('/responses', methods=['POST'])
+    @inlineCallbacks
+    def responses(self, request):
+        logger.info('getting responses...')
+
+        result = yield threads.deferToThread(self.responses_data_handler, request)
+
+        returnValue(result)
+
+    def responses_data_handler(self, request):
+        req_id = request.args['request_id'][0]
+
+        print(req_id)
+        print(self.reqest_list)
+
+        if req_id not in self.reqest_list:
+            response = [{
+                'type': 'PlainText',
+                'content': 'The results of request {} cannot be retrieved'.format(req_id),
+                'label': ''
+            }]
+
+            return json.dumps(response)
+
+        try:
+            response = self.result_dict[req_id]
+            #removing content of list and dict
+            del self.result_dict[req_id]
+            self.reqest_list.remove(req_id)
+        except KeyError:
+            response = [{'type': 'DelayedResponse', 'request_id': req_id}]
+
+
+        return json.dumps(response)


### PR DESCRIPTION
Especially useful for slow services that are returning results after several seconds.

In this case the server sends out a DelayedResponse message that the client has to handle. This message contains a request ID. it's the task of the client to start pining the server at http(s)://hostname/responses with a POST request containing the request ID to see if the results are ready.

the client need to take care of this. when a delayed response is received the client implementation must use the request id passed in the delayed response to periodically ping the server and ask if the real response is there yet.

to do this we have a new endpoint /responses 

the behavior for this endpoint is: 
1 - the response is not yet ready. server will send a new delayed response and trigger a new timer.
2 - there is a valid response. this is sent as it would have been when no delayed response was implemented
3 - the request id used for querying is invalid. a plain text response with an error is returned

Note that this should be used only for servers that are very slow because this sort of active polling of the resource may take more time than the actual processing time for the request.