### PR TITLE
Switch from HTTP to HTTPS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ click
 tinydb
 m2r
 sphinxcontrib-googleanalytics
+pyOpenSSL

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
         'requests',
         'click',
         'tinydb',
+        'pyOpenSSL',
     ],
 )

--- a/tomaat/examples/simple.py
+++ b/tomaat/examples/simple.py
@@ -1,0 +1,50 @@
+import sys, os
+# We need to add "tomaat"-directory (../..) to PATH to import the tomaat package
+sys.path.append( os.path.dirname(os.path.dirname(os.path.abspath(os.path.dirname(__file__)))))
+
+from tomaat.server import TomaatService, TomaatApp
+
+import SimpleITK as sitk
+import numpy as np
+
+config = {
+    "name": "Example TOMAAT thresholding app",
+    "modality": "Example Modality",
+    "task": "Example Task",
+    "anatomy": "Example Anatomy",
+    "description":"Example Description",
+    "port": 9001,
+    "announce": False,
+    "api_key": "",
+}
+
+iface_in = [{'type':'volume','destination':'images'}]
+iface_out = [{'type':'LabelVolume','field':'images'}]
+
+def preprocess(input):
+    return {'images':[sitk.ReadImage(input['images'][0])] }
+
+def inference(data):
+    itk_image = data['images'][0]
+    image_data = sitk.GetArrayFromImage(itk_image)
+    treshold = np.mean(image_data)
+    image_binary = image_data >= treshold
+    return {
+        'image_data': image_binary,
+        'image_old': itk_image,
+    }
+
+def postprocess(output):
+    binarized_image = output['image_data'].astype(np.float)
+    image_new = sitk.GetImageFromArray(binarized_image)
+    image_new.CopyInformation(output['image_old'])
+    return {
+        'images':[image_new]
+    }
+
+
+my_app = TomaatApp(preprocess,inference,postprocess)
+
+my_service = TomaatService(config, my_app, iface_in, iface_out)
+
+my_service.run()

--- a/tomaat/server/makecert.py
+++ b/tomaat/server/makecert.py
@@ -1,0 +1,36 @@
+from OpenSSL import crypto, SSL
+from socket import gethostname
+from pprint import pprint
+from time import gmtime, mktime
+from os.path import exists
+
+def create_self_signed_cert(CERT_FILE = "./tomaat.crt",KEY_FILE = "./tomaat.key"):
+    if not exists(CERT_FILE) or not exists(KEY_FILE):
+        # create a key pair
+        k = crypto.PKey()
+        k.generate_key(crypto.TYPE_RSA, 4096)
+
+        # create a self-signed cert
+        cert = crypto.X509()
+        cert.get_subject().C = "US"
+        cert.get_subject().ST = "TOMAAT"
+        cert.get_subject().L = "TOMAAT"
+        cert.get_subject().O = "TOMAAT"
+        cert.get_subject().OU = "TOMAAT"
+        cert.get_subject().CN = "*"
+        cert.set_serial_number(1000)
+        cert.gmtime_adj_notBefore(0)
+        cert.gmtime_adj_notAfter(10*365*24*60*60)
+        cert.set_issuer(cert.get_subject())
+        cert.set_pubkey(k)
+        cert.sign(k, 'sha256')
+        cert.sign(k, 'sha1')
+
+        # write keys
+        with open(CERT_FILE, "wb") as f:
+            f.write(crypto.dump_certificate(crypto.FILETYPE_PEM, cert))
+        with open(KEY_FILE, "wb") as f:
+            f.write(crypto.dump_privatekey(crypto.FILETYPE_PEM, k))
+
+if __name__ == "__main__":
+    create_self_signed_cert(".")

--- a/tomaat/server/service.py
+++ b/tomaat/server/service.py
@@ -124,7 +124,7 @@ class TomaatService(object):
         request.setHeader('Access-Control-Allow-Origin', '*')
         request.setHeader('Access-Control-Allow-Methods', 'GET')
         request.setHeader('Access-Control-Allow-Headers', '*')
-        request.setHeader('Access-Control-Max-Age', 2520)  # 42 hours
+        request.setHeader('Access-Control-Max-Age', '2520')  # 42 hours
 
         return json.dumps(self.input_interface)
 
@@ -134,7 +134,7 @@ class TomaatService(object):
         request.setHeader('Access-Control-Allow-Origin', '*')
         request.setHeader('Access-Control-Allow-Methods', 'POST')
         request.setHeader('Access-Control-Allow-Headers', '*')
-        request.setHeader('Access-Control-Max-Age', 2520)  # 42 hours
+        request.setHeader('Access-Control-Max-Age', '520')  # 42 hours
 
         logger.info('predicting...')
 

--- a/tomaat/server/service.py
+++ b/tomaat/server/service.py
@@ -118,6 +118,29 @@ class TomaatService(object):
 
         self.input_interface = input_interface
         self.output_interface = output_interface
+        if not "cert_path" in self.config.keys():
+            self.config["cert_path"] = "./tomaat_cert"
+
+        cert_private = self.config["cert_path"] + ".key"
+        cert_public = self.config["cert_path"] + ".crt"
+
+        if not os.path.exists(cert_private) or not os.path.exists(cert_public):
+            from . import makecert
+            makecert.create_self_signed_cert(cert_public,cert_private)
+
+        # setup https
+        endpoint_specification = "ssl:{}".format(self.config['port'])
+        endpoint_specification += ":certKey="+cert_public
+        endpoint_specification += ":privateKey="+cert_private
+
+        self.config['endpoint_specification'] = endpoint_specification
+
+
+    @klein_app.route('/announcePoint', methods=['GET'])
+    def announcePoint(self, request):
+        try: ap = self.config['announcement']
+        except: ap = ""
+        return json.dumps({"announced_at":ap})
 
     @klein_app.route('/interface', methods=['GET'])
     def interface(self, request):
@@ -391,7 +414,9 @@ class TomaatService(object):
         return json.dumps(response)
 
     def run(self):
-        self.klein_app.run(port=self.config['port'], host='0.0.0.0')
+        endpoint_specification = self.config.get("endpoint_specification",None)
+
+        self.klein_app.run(port=self.config['port'], host='0.0.0.0', endpoint_description=endpoint_specification)
         reactor.run()
 
 


### PR DESCRIPTION
This most likely introduce issues with Python 2.x
However, Python2 will be EOL by the end of this year.
Slicer switched to Python 3 in the latest nightly builds. An complementary pull request for the Slicer module is coming soon. 